### PR TITLE
[Selina, PigBag] Step5-2. 사진 앨범 접근

### DIFF
--- a/PhotoAlbum/PhotoAlbum.xcodeproj/project.pbxproj
+++ b/PhotoAlbum/PhotoAlbum.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N6KUR9465F;
+				DEVELOPMENT_TEAM = P9G6PC5FMA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoAlbum/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -539,6 +539,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -567,6 +568,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -28,15 +28,13 @@ final class ViewController: UIViewController {
         collectionView.reloadData() // 화면 전환할 때마다 데이터 reload
     }
     
-//    private func
-    
 }
 
 
 
 extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return allPhotos!.count
+        return allPhotos?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -53,14 +51,15 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
         
         //이미지 캐싱.
         let cachingPhotos = self.allPhotos!.objects(at: IndexSet(integersIn: 0..<allPhotos!.count))
-        cacheManager.startCachingImages(for: cachingPhotos, targetSize: CGSize(width: 100, height: 100), contentMode: .aspectFill, options: nil)
+        cacheManager.startCachingImages(for: cachingPhotos, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil)
         
         // 이미지 불러오기
-        imageManger.requestImage(for: asset!, targetSize: CGSize(width: 100, height: 100), contentMode: .aspectFill, options: nil, resultHandler: {
+        imageManger.requestImage(for: asset!, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil, resultHandler: {
             // 이미지 불러오기 성공
             // 이전에 주입한 cell의 identifier와 asset의 identifier가 같은 경우, 이미지 넣기
             image, _ in if cell.representedIdentifier == asset?.localIdentifier {
                 cell.imageView.image = image
+                cell.imageView.contentMode = .scaleToFill
             }
         })
         return cell

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -9,25 +9,35 @@ import Photos
 import UIKit
 
 final class ViewController: UIViewController {
-    private var allPhotos: PHFetchResult<PHAsset>? // 가져올 asset
-    private let cacheManager = PHCachingImageManager()
-    private let imageManger = PHImageManager()
-    
+    private var allPhotos: PHFetchResult<PHAsset>?
+    private let imageManager = PHCachingImageManager()
     
     @IBOutlet weak var collectionView: UICollectionView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.allPhotos = PHAsset.fetchAssets(with: nil) // 조건 (nil)에 맞는 모든 asset 가져오기
+        self.allPhotos = PHAsset.fetchAssets(with: nil)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        collectionView.reloadData() // 화면 전환할 때마다 데이터 reload
+        collectionView.reloadData()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        configureCachingPhotos()
+    }
+    
+    private func configureCachingPhotos() {
+        let visibleCellCount = collectionView.visibleCells.count // 28
+        let cachingPhotos = self.allPhotos!.objects(at: IndexSet(integersIn: visibleCellCount - 10..<allPhotos!.count)) // 18..<50
+        imageManager.startCachingImages(for: cachingPhotos, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil)
+        imageManager.stopCachingImagesForAllAssets()
+    }
 }
 
 
@@ -38,25 +48,16 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        // allPhoto에서 indexPath에 해당하는 아이템을 가져와서 asset에 저장
         let asset = self.allPhotos?.object(at: indexPath.item)
         
         let cellIdentifier = "imageCell"
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier, for: indexPath) as? ImageCollectionViewCell else {
             return UICollectionViewCell()
         }
-        
-        // asset의 고유 식별자를 cell의 식별자에 주입
+
         cell.representedIdentifier = asset?.localIdentifier
         
-        //이미지 캐싱.
-        let cachingPhotos = self.allPhotos!.objects(at: IndexSet(integersIn: 0..<allPhotos!.count))
-        cacheManager.startCachingImages(for: cachingPhotos, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil)
-        
-        // 이미지 불러오기
-        imageManger.requestImage(for: asset!, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil, resultHandler: {
-            // 이미지 불러오기 성공
-            // 이전에 주입한 cell의 identifier와 asset의 identifier가 같은 경우, 이미지 넣기
+        imageManager.requestImage(for: asset!, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil, resultHandler: {
             image, _ in if cell.representedIdentifier == asset?.localIdentifier {
                 cell.imageView.image = image
                 cell.imageView.contentMode = .scaleToFill

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -18,6 +18,13 @@ final class ViewController: UIViewController {
         super.viewDidLoad()
         
         self.allPhotos = PHAsset.fetchAssets(with: nil)
+        
+        switch PHPhotoLibrary.authorizationStatus() {
+            case .authorized:
+                PHPhotoLibrary.shared().register(self)
+            default:
+                PHPhotoLibrary.shared().register(self)
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -69,5 +76,16 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let length = 100
         return CGSize(width: length, height: length)
+    }
+}
+
+
+extension ViewController: PHPhotoLibraryChangeObserver {
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        self.allPhotos = PHAsset.fetchAssets(with: nil)
+        
+        DispatchQueue.main.async {
+            self.collectionView.reloadData()
+        }
     }
 }


### PR DESCRIPTION
## 💻 작업 목록

- [x] Image Cache 코드 분리
- [x] stopCaching 메소드 추가 
- [x] PHPhotoLibrary Observer 추가

## 📱 실행 화면

<img width="466" alt="스크린샷 2022-03-24 오후 2 28 48" src="https://user-images.githubusercontent.com/95578975/159848714-88a0ec8b-d8f3-4120-a257-8a79b7d18433.png">

## 🤔 고민과 해결

### 1️⃣ 시뮬레이션에서 Bound 에러가 나서 Crash가 계속 남

- 시뮬레이터 안에 있는 사진의 갯수와 CollectionView의 Cell 갯수가 달라서 생긴 문제
- 가져오는 CollectionViewCell의 수를 시뮬레이터에 있는 사진 갯수만큼 가져오도록 해서 해결

### 2️⃣ PHPhotoLibraryChangeObserver를 확인하기 위해서 개인 핸드폰으로 캡쳐를 해서 image를 추가해보고 , 삭제도 해보았으나 앨범안의 숫자는 변화가 없어 보였음. 

- PHPhotoLibraryChangeObserver가 변화를 관찰할 때마다 기존에 저장한 PHAsset을 새롭게 저장하고, reloadData를 하여 해결

```swift
func photoLibraryDidChange(_ changeInstance: PHChange) {
    self.allPhotos = PHAsset.fetchAssets(with: nil)
    
    DispatchQueue.main.async {
        self.collectionView.reloadData()
    }
}
```

## ❓ 질문 거리

이미지 캐싱을 할 때, 저희가 생각한 이미지 캐싱의 범위는 보이는 사진을 제외한 이제 스크롤 되어 보여질 사진들이라고 생각했습니다.

시뮬레이터로 실행했을 때 한 화면에 보여지는 사진의 수는 28개였고, 안전하게 캐싱하기 위해 18..<50 범위의 사진을 캐싱했습니다.

그래서 아래 코드처럼 `objects(at: )` 부분에서 임의로 값을 주어 캐싱했습니다. 이런 식으로 이미지를 캐싱하는 방법이 괜찮을까요?

```swift
private func configureCachingPhotos() {
    let visibleCellCount = collectionView.visibleCells.count // 28
    let cachingPhotos = self.allPhotos!.objects(at: IndexSet(integersIn: visibleCellCount - 10..<allPhotos!.count)) // 18..<50
    imageManager.startCachingImages(for: cachingPhotos, targetSize: CGSize(width: 100, height: 100), contentMode: .default, options: nil)
    imageManager.stopCachingImagesForAllAssets()
}
```

## 💡 학습 키워드

- PHAsset
- PHCachingImageManger
- PHPhotoLibrary
- IndexSet